### PR TITLE
Add Letta archival memory + Unstructured Transform MCP notebook

### DIFF
--- a/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
@@ -25,7 +25,7 @@
     "- **`UNSTRUCTURED_API_KEY`** from [platform.unstructured.io](https://platform.unstructured.io), the Bearer token for the Transform MCP server.\n",
     "- **`OPENAI_API_KEY`** from [platform.openai.com](https://platform.openai.com), used to run the parsing agent.\n",
     "\n",
-    "**A note on the Letta model handles.** The `LETTA_MODEL` and `LETTA_EMBEDDING` set below use `openai/...` handles, which run on Letta's hosted models and draw on your Letta credits. If you would rather use your own OpenAI account, add your OpenAI API key on the Letta Platform [models page](https://docs.letta.com/guides/build-with-letta/models/): it then shows up as a handle under your provider's name (for example `my-openai/gpt-4.1`) and is billed by OpenAI directly. Set `LETTA_MODEL` and `LETTA_EMBEDDING` to whichever handles your workspace can run (check `letta.models.list()`)."
+    "**A note on the Letta model handles.** The `LETTA_MODEL` and `LETTA_EMBEDDING` set below use `openai/...` handles, which run on Letta's hosted models and draw on your Letta credits. If you would rather use your own OpenAI account, add your OpenAI API key on the Letta Platform: it then shows up as a handle under your provider's name (for example `my-openai/gpt-5.6-sol`) and is billed by OpenAI directly. Set `LETTA_MODEL` and `LETTA_EMBEDDING` to whichever handles your workspace can run (check `letta.models.list()`)."
    ]
   },
   {

--- a/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
@@ -22,7 +22,7 @@
     "Three API keys:\n",
     "\n",
     "- **`LETTA_API_KEY`** from [app.letta.com](https://app.letta.com) for the agent and its memory.\n",
-    "- **`UNSTRUCTURED_API_KEY`** Sign up at [here](https://unstructured.io/?modal=try-for-free). Login, and fetch the API Key for the Transform MCP server.\n",
+    "- **`UNSTRUCTURED_API_KEY`** Sign up at [https://unstructured.io/](https://unstructured.io/?modal=try-for-free). Login, and fetch the API Key for the Transform MCP server.\n",
     "- **`OPENAI_API_KEY`** from [platform.openai.com](https://platform.openai.com), used to run the parsing agent.\n",
     "\n",
     "**A note on the Letta model handles.** The `LETTA_MODEL` and `LETTA_EMBEDDING` set below use `openai/...` handles, which run on Letta's hosted models and draw on your Letta credits. If you would rather use your own OpenAI account, add your OpenAI API key on the Letta Platform: it then shows up as a handle under your provider's name (for example `my-openai/gpt-5.6-sol`) and is billed by OpenAI directly. Set `LETTA_MODEL` and `LETTA_EMBEDDING` to whichever handles your workspace can run (check `letta.models.list()`)."

--- a/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
@@ -22,7 +22,7 @@
     "Three API keys:\n",
     "\n",
     "- **`LETTA_API_KEY`** from [app.letta.com](https://app.letta.com) for the agent and its memory.\n",
-    "- **`UNSTRUCTURED_API_KEY`** from [transform.unstructured.io](https://transform.unstructured.io), the API Key for the Transform MCP server.\n",
+    "- **`UNSTRUCTURED_API_KEY`** Sign up at [here](https://unstructured.io/?modal=try-for-free). Login, and fetch the API Key for the Transform MCP server.\n",
     "- **`OPENAI_API_KEY`** from [platform.openai.com](https://platform.openai.com), used to run the parsing agent.\n",
     "\n",
     "**A note on the Letta model handles.** The `LETTA_MODEL` and `LETTA_EMBEDDING` set below use `openai/...` handles, which run on Letta's hosted models and draw on your Letta credits. If you would rather use your own OpenAI account, add your OpenAI API key on the Letta Platform: it then shows up as a handle under your provider's name (for example `my-openai/gpt-5.6-sol`) and is billed by OpenAI directly. Set `LETTA_MODEL` and `LETTA_EMBEDDING` to whichever handles your workspace can run (check `letta.models.list()`)."

--- a/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0e29fadc",
+   "metadata": {},
+   "source": [
+    "# Give a Letta agent a document to remember: Unstructured Transform MCP + archival memory\n",
+    "\n",
+    "This notebook turns a document into knowledge that a [Letta](https://docs.letta.com) agent carries with it. We parse the file with the [Unstructured](https://unstructured.io) **Transform MCP server**, load the result into the agent's [archival memory](https://docs.letta.com/guides/core-concepts/memory/archival-memory), and then ask questions. The agent retrieves only the passages it needs for each question, so the document becomes a reliable reference the agent can draw on in any future conversation.\n",
+    "\n",
+    "The [Unstructured Transform MCP server](https://docs.unstructured.io/transform/overview) converts PDFs, DOCX, PPTX, spreadsheets, HTML, images, and 60+ other formats into clean markdown. We drive it with an agent using the OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses), then hand the markdown to Letta."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efa1f93e",
+   "metadata": {},
+   "source": [
+    "## 1. Prerequisites\n",
+    "\n",
+    "Three API keys:\n",
+    "\n",
+    "- **`LETTA_API_KEY`** from [app.letta.com](https://app.letta.com) for the agent and its memory.\n",
+    "- **`UNSTRUCTURED_API_KEY`** from [platform.unstructured.io](https://platform.unstructured.io), the Bearer token for the Transform MCP server.\n",
+    "- **`OPENAI_API_KEY`** from [platform.openai.com](https://platform.openai.com), used to run the parsing agent.\n",
+    "\n",
+    "**A note on the Letta model handles.** The `LETTA_MODEL` and `LETTA_EMBEDDING` set below use `openai/...` handles, which run on Letta's hosted models and draw on your Letta credits. If you would rather use your own OpenAI account, add your OpenAI API key on the Letta Platform [models page](https://docs.letta.com/guides/build-with-letta/models/): it then shows up as a handle under your provider's name (for example `my-openai/gpt-4.1`) and is billed by OpenAI directly. Set `LETTA_MODEL` and `LETTA_EMBEDDING` to whichever handles your workspace can run (check `letta.models.list()`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eac96d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade openai letta-client requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "208ef460",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, re, json, time\n",
+    "import getpass\n",
+    "import requests\n",
+    "from openai import OpenAI\n",
+    "from letta_client import Letta\n",
+    "\n",
+    "for var in (\"LETTA_API_KEY\", \"UNSTRUCTURED_API_KEY\", \"OPENAI_API_KEY\"):\n",
+    "    if not os.environ.get(var):\n",
+    "        os.environ[var] = getpass.getpass(f\"{var}: \")\n",
+    "\n",
+    "TRANSFORM_MCP_URL = \"https://mcp.transform.unstructured.io/\"\n",
+    "PDF_URL = \"https://arxiv.org/pdf/1706.03762\"  # 'Attention Is All You Need'\n",
+    "\n",
+    "# Model that runs the parsing agent (OpenAI Responses API).\n",
+    "OPENAI_MODEL = \"gpt-5-mini\"\n",
+    "\n",
+    "# Model and embedding handles for the Letta agent (see letta.models.list()). Bare 'openai/...' and\n",
+    "# 'letta/...' handles bill Letta credits; a key added in the Letta portal appears under its own\n",
+    "# provider prefix and bills that key.\n",
+    "LETTA_MODEL = \"openai/gpt-4.1\"\n",
+    "LETTA_EMBEDDING = \"openai/text-embedding-3-small\"\n",
+    "\n",
+    "openai_client = OpenAI(api_key=os.environ[\"OPENAI_API_KEY\"])\n",
+    "letta = Letta(api_key=os.environ[\"LETTA_API_KEY\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e83c85b4",
+   "metadata": {},
+   "source": [
+    "## 2. Parse the document with an agent\n",
+    "\n",
+    "The Transform MCP server is a remote MCP server, so we attach it directly to the OpenAI Responses API as an MCP tool. Parsing runs as an asynchronous job, so we also give the model a `wait_seconds` tool it can call between status checks. The agent submits the job with `transform_files`, polls `check_transform_status` until it is `COMPLETED`, and calls `get_transform_results` for the markdown. We then download and return it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "663a7439",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def transform_mcp_tool():\n",
+    "    \"\"\"Responses API MCP tool block for the Unstructured Transform server.\"\"\"\n",
+    "    return {\n",
+    "        \"type\": \"mcp\",\n",
+    "        \"server_label\": \"unstructured_transform\",\n",
+    "        \"server_url\": TRANSFORM_MCP_URL,\n",
+    "        \"require_approval\": \"never\",\n",
+    "        \"headers\": {\"Authorization\": f\"Bearer {os.environ['UNSTRUCTURED_API_KEY']}\"},\n",
+    "    }\n",
+    "\n",
+    "def wait_seconds(seconds):\n",
+    "    \"\"\"Wait before checking the job status again, so the agent can wait out a slow job.\"\"\"\n",
+    "    time.sleep(seconds)\n",
+    "    return f\"Waited {seconds} seconds.\"\n",
+    "\n",
+    "WAIT_TOOL = {\n",
+    "    \"type\": \"function\", \"name\": \"wait_seconds\",\n",
+    "    \"description\": \"Wait the given number of seconds before checking the job status again.\",\n",
+    "    \"parameters\": {\"type\": \"object\", \"properties\": {\"seconds\": {\"type\": \"integer\"}},\n",
+    "                   \"required\": [\"seconds\"], \"additionalProperties\": False},\n",
+    "}\n",
+    "\n",
+    "MARKDOWN_URL = re.compile(r\"https://mcp\\.transform\\.unstructured\\.io/output/\\S+?\\.md[^\\\"\\\\ ]*\")\n",
+    "\n",
+    "# Cap on the number of client-side tool round-trips (mostly wait_seconds polls). The loop exits as\n",
+    "# soon as the agent stops calling tools; this is just a safety bound so it can never spin forever.\n",
+    "MAX_TOOL_STEPS = 40\n",
+    "\n",
+    "def parse_to_markdown(url):\n",
+    "    \"\"\"Let the model drive Transform and return the parsed markdown.\"\"\"\n",
+    "    tools = [transform_mcp_tool(), WAIT_TOOL]\n",
+    "    instruction = (\n",
+    "        f\"Parse the PDF at {url} using the Unstructured Transform tools. Call transform_files with the \"\n",
+    "        \"URL, then poll check_transform_status, calling wait_seconds(10) between each check, until the \"\n",
+    "        \"status is COMPLETED. Then call get_transform_results with output_format 'md' and report the \"\n",
+    "        \"markdown download URL.\"\n",
+    "    )\n",
+    "    resp = openai_client.responses.create(model=OPENAI_MODEL, tools=tools, input=instruction)\n",
+    "    seen = json.dumps(resp.model_dump())\n",
+    "    for _ in range(MAX_TOOL_STEPS):\n",
+    "        calls = [o for o in resp.output if o.type == \"function_call\"]\n",
+    "        if not calls:\n",
+    "            break\n",
+    "        outputs = []\n",
+    "        for call in calls:\n",
+    "            args = json.loads(call.arguments)\n",
+    "            result = wait_seconds(**args) if call.name == \"wait_seconds\" else \"unknown tool\"\n",
+    "            outputs.append({\"type\": \"function_call_output\", \"call_id\": call.call_id, \"output\": result})\n",
+    "        resp = openai_client.responses.create(model=OPENAI_MODEL, tools=tools,\n",
+    "                                              previous_response_id=resp.id, input=outputs)\n",
+    "        seen += \"\\n\" + json.dumps(resp.model_dump())\n",
+    "    urls = MARKDOWN_URL.findall(seen)\n",
+    "    if not urls:\n",
+    "        raise RuntimeError(\"Transform did not return a markdown URL; check the job status.\")\n",
+    "    return requests.get(urls[0], timeout=120).text\n",
+    "\n",
+    "markdown = parse_to_markdown(PDF_URL)\n",
+    "print(f\"parsed {len(markdown):,} characters of markdown\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d35067f3",
+   "metadata": {},
+   "source": [
+    "## 3. Chunk the markdown\n",
+    "\n",
+    "Transform returns clean markdown with the document's headings intact. We split it into passage-sized chunks and keep the section heading each chunk falls under, so the agent can cite sections in its answers. The result is a simple JSON list of chunks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "344dfdb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chunk_markdown(text, max_chars=1200):\n",
+    "    \"\"\"Split markdown into ~max_chars chunks, tagging each with the section heading it falls under.\"\"\"\n",
+    "    chunks, buffer, size, section = [], [], 0, \"Introduction\"\n",
+    "    for block in text.split(\"\\n\\n\"):\n",
+    "        block = block.strip()\n",
+    "        if not block:\n",
+    "            continue\n",
+    "        is_heading = block.splitlines()[0].lstrip().startswith(\"#\")\n",
+    "        # Close the current chunk at a new heading or when it gets long enough.\n",
+    "        if buffer and (is_heading or size + len(block) > max_chars):\n",
+    "            chunks.append({\"section\": section, \"text\": \"\\n\\n\".join(buffer)})\n",
+    "            buffer, size = [], 0\n",
+    "        if is_heading:\n",
+    "            section = block.splitlines()[0].lstrip(\"#\").strip() or section\n",
+    "        buffer.append(block)\n",
+    "        size += len(block)\n",
+    "    if buffer:\n",
+    "        chunks.append({\"section\": section, \"text\": \"\\n\\n\".join(buffer)})\n",
+    "    return chunks\n",
+    "\n",
+    "chunks = chunk_markdown(markdown)\n",
+    "print(f\"{len(chunks)} chunks\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f27062a",
+   "metadata": {},
+   "source": [
+    "## 4. Load the chunks into the agent's archival memory\n",
+    "\n",
+    "We create a Letta agent and attach its `archival_memory_search` tool, which lets it retrieve stored passages. Then we insert each chunk as an archival-memory passage, prefixed with its section heading. Letta embeds each passage on insert, so the agent can find the right ones by meaning. This ingestion is a one-time step; the passages stay with the agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62d42aeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "archival_search = next(t for t in letta.tools.list(limit=200) if t.name == \"archival_memory_search\")\n",
+    "\n",
+    "agent = letta.agents.create(\n",
+    "    name=\"document-analyst\",\n",
+    "    model=LETTA_MODEL,\n",
+    "    embedding=LETTA_EMBEDDING,\n",
+    "    tool_ids=[archival_search.id],\n",
+    "    memory_blocks=[\n",
+    "        {\n",
+    "            \"label\": \"persona\",\n",
+    "            \"value\": (\n",
+    "                \"I have NOT read the user's document and I have NO prior knowledge of its contents. The \"\n",
+    "                \"only way I can learn anything about it is to call archival_memory_search, where it is \"\n",
+    "                \"stored one passage per section, each prefixed with its section heading. Before answering \"\n",
+    "                \"ANY question I first call archival_memory_search, then answer strictly from the passages \"\n",
+    "                \"it returns and cite the section. If the search returns nothing relevant I say so. I never \"\n",
+    "                \"answer from general knowledge, and I never ask the user to provide or paste the document.\"\n",
+    "            ),\n",
+    "        },\n",
+    "    ],\n",
+    ")\n",
+    "print(\"agent id:\", agent.id)\n",
+    "\n",
+    "for i, chunk in enumerate(chunks):\n",
+    "    letta.agents.passages.create(agent_id=agent.id, text=f\"[{chunk['section']}] {chunk['text']}\")\n",
+    "    if (i + 1) % 10 == 0 or i == len(chunks) - 1:\n",
+    "        print(f\"  loaded {i + 1}/{len(chunks)} passages\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a582a18",
+   "metadata": {},
+   "source": [
+    "## 5. Ask questions\n",
+    "\n",
+    "Retrieval is built in: when we send a question, the agent calls `archival_memory_search`, reads the passages that come back, and answers from them. Each call brings back only the relevant passages, so the whole document never has to fit in the prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cadad47a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask(question):\n",
+    "    response = letta.agents.messages.create(\n",
+    "        agent_id=agent.id,\n",
+    "        messages=[{\"role\": \"user\", \"content\": question}],\n",
+    "    )\n",
+    "    for m in response.messages:\n",
+    "        kind = getattr(m, \"message_type\", None)\n",
+    "        if kind == \"tool_call_message\":\n",
+    "            call = getattr(m, \"tool_call\", None)\n",
+    "            print(\"  [searched archival memory]\" if call and call.name == \"archival_memory_search\"\n",
+    "                  else f\"  [tool] {getattr(call, 'name', '?')}\")\n",
+    "        elif kind == \"assistant_message\":\n",
+    "            print(\"\\n\" + str(m.content))\n",
+    "    return response\n",
+    "\n",
+    "_ = ask(\"Using the document in your archival memory, how does multi-head attention work? Cite the section.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c41ebbac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = ask(\"From your archival memory, what positional encoding does the model use? Cite the section.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43046086",
+   "metadata": {},
+   "source": [
+    "## 6. The document stays in the agent's memory\n",
+    "\n",
+    "The passages live with the agent, so it can answer from this document in any later session without re-parsing or re-uploading. Here is what it is holding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a38a40f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "passages = list(letta.agents.passages.list(agent_id=agent.id))\n",
+    "print(f\"{len(passages)} passages in archival memory\")\n",
+    "print(\"example:\", passages[0].text[:200])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6619076",
+   "metadata": {},
+   "source": [
+    "## Best practices & next steps\n",
+    "\n",
+    "- **Give the agent a document once.** After ingestion the agent answers from archival memory across sessions, which makes this a good fit for a support agent over a manual, a policy document, or a research paper.\n",
+    "- **Make use of Tags** - Self-explanatory :) \n",
+    "- **Only relevant passages enter the prompt.** Each question retrieves a few passages by meaning, so token usage stays low and large documents work fine.\n",
+    "- **Transform handles the hard part.** It turns 60+ messy file formats into clean markdown; limits are 50 MB/file, 10 files/request, and 5 concurrent jobs.\n",
+    "\n",
+    "### Resources\n",
+    "- [Unstructured](https://unstructured.io) and the [Unstructured Transform docs](https://docs.unstructured.io/transform/overview)\n",
+    "- [Letta docs](https://docs.letta.com) and [archival memory](https://docs.letta.com/guides/core-concepts/memory/archival-memory)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
@@ -22,7 +22,7 @@
     "Three API keys:\n",
     "\n",
     "- **`LETTA_API_KEY`** from [app.letta.com](https://app.letta.com) for the agent and its memory.\n",
-    "- **`UNSTRUCTURED_API_KEY`** Sign up at [https://unstructured.io/](https://unstructured.io/?modal=try-for-free). Login, and fetch the API Key for the Transform MCP server.\n",
+    "- **`UNSTRUCTURED_API_KEY`**: Sign up at [unstructured.io](https://unstructured.io/?modal=try-for-free), log in, and retrieve the API key for the Transform MCP server.\n",
     "- **`OPENAI_API_KEY`** from [platform.openai.com](https://platform.openai.com), used to run the parsing agent.\n",
     "\n",
     "**A note on the Letta model handles.** The `LETTA_MODEL` and `LETTA_EMBEDDING` set below use `openai/...` handles, which run on Letta's hosted models and draw on your Letta credits. If you would rather use your own OpenAI account, add your OpenAI API key on the Letta Platform: it then shows up as a handle under your provider's name (for example `my-openai/gpt-5.6-sol`) and is billed by OpenAI directly. Set `LETTA_MODEL` and `LETTA_EMBEDDING` to whichever handles your workspace can run (check `letta.models.list()`)."

--- a/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Give a Letta agent a document to remember: Unstructured Transform MCP + archival memory\n",
     "\n",
-    "This notebook turns a document into knowledge that a [Letta](https://docs.letta.com) agent carries with it. We parse the file with the [Unstructured](https://unstructured.io) **Transform MCP server**, load the result into the agent's [archival memory](https://docs.letta.com/guides/core-concepts/memory/archival-memory), and then ask questions. The agent retrieves only the passages it needs for each question, so the document becomes a reliable reference the agent can draw on in any future conversation.\n",
+    "This notebook turns a document into knowledge that a [Letta](https://docs.letta.com) agent carries with it. We parse the file with the **[Unstructured Transform MCP server](https://docs.unstructured.io/transform/overview)**, load the result into the agent's [archival memory](https://docs.letta.com/guides/core-concepts/memory/archival-memory), and then ask questions. The agent retrieves only the passages it needs for each question, so the document becomes a reliable reference the agent can draw on in any future conversation.\n",
     "\n",
     "The [Unstructured Transform MCP server](https://docs.unstructured.io/transform/overview) converts PDFs, DOCX, PPTX, spreadsheets, HTML, images, and 60+ other formats into clean markdown. We drive it with an agent using the OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses), then hand the markdown to Letta."
    ]
@@ -22,7 +22,7 @@
     "Three API keys:\n",
     "\n",
     "- **`LETTA_API_KEY`** from [app.letta.com](https://app.letta.com) for the agent and its memory.\n",
-    "- **`UNSTRUCTURED_API_KEY`** from [platform.unstructured.io](https://platform.unstructured.io), the Bearer token for the Transform MCP server.\n",
+    "- **`UNSTRUCTURED_API_KEY`** from [transform.unstructured.io](https://transform.unstructured.io), the API Key for the Transform MCP server.\n",
     "- **`OPENAI_API_KEY`** from [platform.openai.com](https://platform.openai.com), used to run the parsing agent.\n",
     "\n",
     "**A note on the Letta model handles.** The `LETTA_MODEL` and `LETTA_EMBEDDING` set below use `openai/...` handles, which run on Letta's hosted models and draw on your Letta credits. If you would rather use your own OpenAI account, add your OpenAI API key on the Letta Platform: it then shows up as a handle under your provider's name (for example `my-openai/gpt-5.6-sol`) and is billed by OpenAI directly. Set `LETTA_MODEL` and `LETTA_EMBEDDING` to whichever handles your workspace can run (check `letta.models.list()`)."
@@ -315,7 +315,7 @@
     "- **Transform handles the hard part.** It turns 60+ messy file formats into clean markdown; limits are 50 MB/file, 10 files/request, and 5 concurrent jobs.\n",
     "\n",
     "### Resources\n",
-    "- [Unstructured](https://unstructured.io) and the [Unstructured Transform docs](https://docs.unstructured.io/transform/overview)\n",
+    "- [Unstructured Transform docs](https://docs.unstructured.io/transform/overview) \n",
     "- [Letta docs](https://docs.letta.com) and [archival memory](https://docs.letta.com/guides/core-concepts/memory/archival-memory)"
    ]
   }


### PR DESCRIPTION
Adds a notebook showing how to give a [Letta](https://docs.letta.com) agent a document to remember, using the Unstructured Transform MCP server.

## What it does
- Parses a PDF with the **Unstructured Transform MCP server**, driven by an agent using the OpenAI Responses API (with a `wait_seconds` tool to poll the async job).
- Chunks the resulting markdown by section heading.
- Loads each chunk into the Letta agent's **archival memory** (`archival_memory_search` attached), so retrieval happens server-side.
- Asks questions: the agent searches its archival memory and answers from the retrieved passages, citing sections. The full document never has to fit in the prompt.

## Prerequisites
`LETTA_API_KEY`, `UNSTRUCTURED_API_KEY`, and `OPENAI_API_KEY` (entered via `getpass`; no keys stored in the notebook). Outputs are cleared.

File: `notebooks/RAG_with_Letta_Archival_Memory_and_Unstructured_Transform_MCP.ipynb`