### PR TITLE
Add Getting Started with Unstructured Transform notebook

### DIFF
--- a/notebooks/Getting_Started_with_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/Getting_Started_with_Unstructured_Transform_MCP.ipynb
@@ -47,19 +47,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "cell-01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:32:13.372184Z",
-     "iopub.status.busy": "2026-07-27T23:32:13.372076Z",
-     "iopub.status.idle": "2026-07-27T23:32:14.919070Z",
-     "shell.execute_reply": "2026-07-27T23:32:14.918433Z"
+     "iopub.execute_input": "2026-07-28T01:48:15.737108Z",
+     "iopub.status.busy": "2026-07-28T01:48:15.736783Z",
+     "iopub.status.idle": "2026-07-28T01:48:17.834892Z",
+     "shell.execute_reply": "2026-07-28T01:48:17.834145Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: openai in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (2.49.0)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: requests in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (2.34.2)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: anyio<5,>=3.5.0 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from openai) (4.14.2)\r\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from openai) (1.9.0)\r\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from openai) (0.28.1)\r\n",
+      "Requirement already satisfied: jiter<1,>=0.10.0 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from openai) (0.16.0)\r\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from openai) (2.13.4)\r\n",
+      "Requirement already satisfied: sniffio in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from openai) (1.3.1)\r\n",
+      "Requirement already satisfied: tqdm>4 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from openai) (4.70.0)\r\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.14 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from openai) (4.16.0)\r\n",
+      "Requirement already satisfied: idna>=2.8 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from anyio<5,>=3.5.0->openai) (3.18)\r\n",
+      "Requirement already satisfied: certifi in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from httpx<1,>=0.23.0->openai) (2026.7.22)\r\n",
+      "Requirement already satisfied: httpcore==1.* in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\r\n",
+      "Requirement already satisfied: h11>=0.16 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\r\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from pydantic<3,>=1.9.0->openai) (0.8.0)\r\n",
+      "Requirement already satisfied: pydantic-core==2.46.4 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from pydantic<3,>=1.9.0->openai) (2.46.4)\r\n",
+      "Requirement already satisfied: typing-inspection>=0.4.2 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from pydantic<3,>=1.9.0->openai) (0.4.2)\r\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from requests) (3.4.9)\r\n",
+      "Requirement already satisfied: urllib3<3,>=1.26 in /Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-nb/lib/python3.13/site-packages (from requests) (2.7.0)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
-%pip install -U openai requests
+    "%pip install -U openai requests"
    ]
   },
   {
@@ -81,22 +126,13 @@
    "id": "cell-03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:32:14.921215Z",
-     "iopub.status.busy": "2026-07-27T23:32:14.921059Z",
-     "iopub.status.idle": "2026-07-27T23:32:15.322197Z",
-     "shell.execute_reply": "2026-07-27T23:32:15.321875Z"
+     "iopub.execute_input": "2026-07-28T01:48:17.836435Z",
+     "iopub.status.busy": "2026-07-28T01:48:17.836302Z",
+     "iopub.status.idle": "2026-07-28T01:48:18.518167Z",
+     "shell.execute_reply": "2026-07-28T01:48:18.517676Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-tutorials/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import math\n",
@@ -143,10 +179,10 @@
    "id": "cell-05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:32:15.323594Z",
-     "iopub.status.busy": "2026-07-27T23:32:15.323522Z",
-     "iopub.status.idle": "2026-07-27T23:32:15.326927Z",
-     "shell.execute_reply": "2026-07-27T23:32:15.326716Z"
+     "iopub.execute_input": "2026-07-28T01:48:18.519676Z",
+     "iopub.status.busy": "2026-07-28T01:48:18.519572Z",
+     "iopub.status.idle": "2026-07-28T01:48:18.545518Z",
+     "shell.execute_reply": "2026-07-28T01:48:18.544972Z"
     }
    },
    "outputs": [],
@@ -237,10 +273,10 @@
    "id": "cell-07",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:32:15.328033Z",
-     "iopub.status.busy": "2026-07-27T23:32:15.327969Z",
-     "iopub.status.idle": "2026-07-27T23:37:12.369951Z",
-     "shell.execute_reply": "2026-07-27T23:37:12.368958Z"
+     "iopub.execute_input": "2026-07-28T01:48:18.546650Z",
+     "iopub.status.busy": "2026-07-28T01:48:18.546580Z",
+     "iopub.status.idle": "2026-07-28T01:51:38.247973Z",
+     "shell.execute_reply": "2026-07-28T01:51:38.247177Z"
     }
    },
    "outputs": [
@@ -248,19 +284,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "I parsed the PDF using the hi_res strategy with enrichments (image_description, table_to_html, generative_ocr) to handle tables and figures well. The job is complete.\n",
+      "The parse is complete. I used the hi_res partition strategy with image_description, generative_ocr, and table_to_html enrichments to better handle figures and tables, and rendered the result as Markdown.\n",
       "\n",
-      "Download the markdown file:\n",
-      "https://mcp.transform.unstructured.io/output/781a7d0f-ed2e-4f0c-af26-a562e0115505_1706-aabb8fdd_md.md?token=...\n",
+      "Download the Markdown here:\n",
+      "https://mcp.transform.unstructured.io/output/539b9ef7-65c6-41e3-99d5-57b57f15bdd8_1706-27779320_md.md?token=...\n",
       "\n",
-      "One‑liner to save it locally:\n",
-      "curl -fSs -o attention_is_all_you_need.md 'https://mcp.transform.unstructured.io/output/781a7d0f-ed2e-4f0c-af26-a562e0115505_1706-aabb8fdd_md.md?token=...'\n",
+      "One-liner to save it locally:\n",
+      "curl -fSs -o attention_is_all_you_need.md 'https://mcp.transform.unstructured.io/output/539b9ef7-65c6-41e3-99d5-57b57f15bdd8_1706-27779320_md.md?token=...'\n",
       "\n",
-      "Notes:\n",
-      "- Link expires: 2026-07-28T00:36:59Z. If it lapses, I can re-mint it instantly.\n",
-      "- Parse output ref (for further processing/extraction without re-parsing): u10d://output/781a7d0f-ed2e-4f0c-af26-a562e0115505_1706-aabb8fdd.json\n",
+      "Details:\n",
+      "- Size: ~44 KB\n",
+      "- Expires: 2026-07-28T02:51:25Z\n",
+      "- Re-mintable: If it expires, I can re-mint a fresh link instantly.\n",
+      "- Output ref (for chaining to extraction or re-rendering): u10d://output/539b9ef7-65c6-41e3-99d5-57b57f15bdd8_1706-27779320.json\n",
       "\n",
-      "If you want me to paste the markdown content here, please download the file and upload/share a readable path, and I’ll return its contents.\n"
+      "Want me to also provide an HTML or TXT render, or extract sections (abstract, equations, tables) into structured JSON?\n"
      ]
     }
    ],
@@ -288,10 +326,10 @@
    "id": "cell-09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:37:12.374885Z",
-     "iopub.status.busy": "2026-07-27T23:37:12.374750Z",
-     "iopub.status.idle": "2026-07-27T23:37:13.027237Z",
-     "shell.execute_reply": "2026-07-27T23:37:13.026672Z"
+     "iopub.execute_input": "2026-07-28T01:51:38.250354Z",
+     "iopub.status.busy": "2026-07-28T01:51:38.250147Z",
+     "iopub.status.idle": "2026-07-28T01:51:39.011327Z",
+     "shell.execute_reply": "2026-07-28T01:51:39.009381Z"
     }
    },
    "outputs": [
@@ -299,7 +337,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "44,848 characters\n",
+      "44,308 characters\n",
       "\n",
       "<table><thead><tr><th>Layer Type</th><th>Complexity per Layer</th><th>Sequential Operations</th><th>Maximum Path Length</th></tr></thead><tbody><tr><td>Self-Attention</td><td>O(n² · d)</td><td>O(1)</td><td>O(1)</td></tr><tr><td>Recurrent</td><td>O(n · d²)</td><td>O(n)</td><td>O(n)</td></tr><tr><td>Convolutional</td><td>O(k · n · d²)</td><td>O(1)</td><td>O(log_k(n))</td></tr><tr><td>Self-Attention (restricted)</td><td>O(r · n · d)</td><td>O(1)</td><td>O(n/r)</td></tr></tbody></table>\n",
       "\n",
@@ -311,7 +349,9 @@
    ],
    "source": [
     "files = results[\"get_job_results\"][\"files\"]\n",
-    "markdown = requests.get(files[0][\"download_url\"], timeout=120).text\n",
+    "download = requests.get(files[0][\"download_url\"], timeout=120)\n",
+    "download.raise_for_status()  # links expire after an hour, so fail loudly if this one has\n",
+    "markdown = download.text\n",
     "open(DOC_PATH, \"w\", encoding=\"utf-8\").write(markdown)\n",
     "\n",
     "parsed_doc = files[0][\"output_ref\"]  # reusable handle, we come back to this twice\n",
@@ -338,10 +378,10 @@
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:37:13.029368Z",
-     "iopub.status.busy": "2026-07-27T23:37:13.029211Z",
-     "iopub.status.idle": "2026-07-27T23:37:13.034612Z",
-     "shell.execute_reply": "2026-07-27T23:37:13.034187Z"
+     "iopub.execute_input": "2026-07-28T01:51:39.017320Z",
+     "iopub.status.busy": "2026-07-28T01:51:39.017108Z",
+     "iopub.status.idle": "2026-07-28T01:51:39.025082Z",
+     "shell.execute_reply": "2026-07-28T01:51:39.024145Z"
     }
    },
    "outputs": [],
@@ -394,10 +434,10 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:37:13.036227Z",
-     "iopub.status.busy": "2026-07-27T23:37:13.036084Z",
-     "iopub.status.idle": "2026-07-27T23:37:13.039731Z",
-     "shell.execute_reply": "2026-07-27T23:37:13.039341Z"
+     "iopub.execute_input": "2026-07-28T01:51:39.027150Z",
+     "iopub.status.busy": "2026-07-28T01:51:39.026878Z",
+     "iopub.status.idle": "2026-07-28T01:51:39.032463Z",
+     "shell.execute_reply": "2026-07-28T01:51:39.031636Z"
     }
    },
    "outputs": [],
@@ -443,10 +483,10 @@
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:37:13.041439Z",
-     "iopub.status.busy": "2026-07-27T23:37:13.041339Z",
-     "iopub.status.idle": "2026-07-27T23:37:23.345343Z",
-     "shell.execute_reply": "2026-07-27T23:37:23.344688Z"
+     "iopub.execute_input": "2026-07-28T01:51:39.034405Z",
+     "iopub.status.busy": "2026-07-28T01:51:39.034293Z",
+     "iopub.status.idle": "2026-07-28T01:51:46.129048Z",
+     "shell.execute_reply": "2026-07-28T01:51:46.127924Z"
     }
    },
    "outputs": [
@@ -454,11 +494,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "They use fixed sinusoidal positional encodings (sine and cosine functions of different frequencies) added to the input embeddings. The authors chose this because:\n",
-      "- It should let the model easily learn relative positions (for any fixed offset k, PEpos+k is a linear function of PEpos).\n",
-      "- It may extrapolate to sequence lengths longer than those seen in training, while performing similarly to learned positional embeddings.\n",
+      "It uses fixed sinusoidal positional encodings (sine and cosine at different frequencies) added to the input embeddings. The authors chose this because it lets the model easily attend by relative positions (PEpos+k is a linear function of PEpos) and may allow extrapolation to sequence lengths longer than those seen in training; they observed similar performance to learned positional embeddings but preferred the sinusoidal version for this extrapolation property.\n",
       "\n",
-      "Source: Section 3.5 Positional Encoding\n"
+      "Source: 3.5 Positional Encoding\n"
      ]
     }
    ],
@@ -472,10 +510,10 @@
    "id": "cell-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:37:23.348650Z",
-     "iopub.status.busy": "2026-07-27T23:37:23.348389Z",
-     "iopub.status.idle": "2026-07-27T23:37:33.177462Z",
-     "shell.execute_reply": "2026-07-27T23:37:33.176730Z"
+     "iopub.execute_input": "2026-07-28T01:51:46.132009Z",
+     "iopub.status.busy": "2026-07-28T01:51:46.131800Z",
+     "iopub.status.idle": "2026-07-28T01:51:53.030242Z",
+     "shell.execute_reply": "2026-07-28T01:51:53.029121Z"
     }
    },
    "outputs": [
@@ -533,10 +571,10 @@
    "id": "cell-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:37:33.180335Z",
-     "iopub.status.busy": "2026-07-27T23:37:33.180084Z",
-     "iopub.status.idle": "2026-07-27T23:38:31.956502Z",
-     "shell.execute_reply": "2026-07-27T23:38:31.955822Z"
+     "iopub.execute_input": "2026-07-28T01:51:53.033638Z",
+     "iopub.status.busy": "2026-07-28T01:51:53.033371Z",
+     "iopub.status.idle": "2026-07-28T01:53:15.769126Z",
+     "shell.execute_reply": "2026-07-28T01:53:15.767440Z"
     }
    },
    "outputs": [],
@@ -556,10 +594,10 @@
    "id": "cell-18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:38:31.961183Z",
-     "iopub.status.busy": "2026-07-27T23:38:31.960865Z",
-     "iopub.status.idle": "2026-07-27T23:38:33.406124Z",
-     "shell.execute_reply": "2026-07-27T23:38:33.405733Z"
+     "iopub.execute_input": "2026-07-28T01:53:15.774565Z",
+     "iopub.status.busy": "2026-07-28T01:53:15.774145Z",
+     "iopub.status.idle": "2026-07-28T01:53:17.195566Z",
+     "shell.execute_reply": "2026-07-28T01:53:17.194858Z"
     }
    },
    "outputs": [
@@ -567,13 +605,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "71 chunks, 1536 dimensions each\n"
+      "70 chunks, 1536 dimensions each\n"
      ]
     }
    ],
    "source": [
     "files = results[\"get_job_results\"][\"files\"]\n",
-    "elements = requests.get(files[0][\"download_url\"], timeout=120).json()\n",
+    "download = requests.get(files[0][\"download_url\"], timeout=120)\n",
+    "download.raise_for_status()\n",
+    "elements = download.json()\n",
     "\n",
     "chunks = [\n",
     "    {\n",
@@ -601,14 +641,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "cell-20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:38:33.407960Z",
-     "iopub.status.busy": "2026-07-27T23:38:33.407825Z",
-     "iopub.status.idle": "2026-07-27T23:38:34.003050Z",
-     "shell.execute_reply": "2026-07-27T23:38:34.002609Z"
+     "iopub.execute_input": "2026-07-28T01:53:17.197804Z",
+     "iopub.status.busy": "2026-07-28T01:53:17.197644Z",
+     "iopub.status.idle": "2026-07-28T01:53:18.936893Z",
+     "shell.execute_reply": "2026-07-28T01:53:18.936282Z"
     }
    },
    "outputs": [
@@ -631,7 +671,7 @@
     "    return dot / (math.sqrt(sum(x * x for x in a)) * math.sqrt(sum(y * y for y in b)))\n",
     "\n",
     "\n",
-    "def search(question, k=3): # extremely vanilla function don't mind\n",
+    "def search(question, k=3):\n",
     "    \"\"\"Find the chunks closest in meaning to the question.\"\"\"\n",
     "    q = client.embeddings.create(model=EMBED_MODEL, input=question).data[0].embedding\n",
     "    return sorted(chunks, key=lambda c: cosine(q, c[\"vector\"]), reverse=True)[:k]\n",
@@ -650,10 +690,10 @@
    "id": "cell-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:38:34.005003Z",
-     "iopub.status.busy": "2026-07-27T23:38:34.004861Z",
-     "iopub.status.idle": "2026-07-27T23:38:40.598878Z",
-     "shell.execute_reply": "2026-07-27T23:38:40.597995Z"
+     "iopub.execute_input": "2026-07-28T01:53:18.939456Z",
+     "iopub.status.busy": "2026-07-28T01:53:18.939274Z",
+     "iopub.status.idle": "2026-07-28T01:53:29.108046Z",
+     "shell.execute_reply": "2026-07-28T01:53:29.106343Z"
     }
    },
    "outputs": [
@@ -661,7 +701,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The model uses sinusoidal positional encodings—sine and cosine functions at different frequencies—added to the input embeddings. The authors chose this because the sinusoids let the model learn relative positions (PEpos+k is a linear function of PEpos) and may enable extrapolation to longer sequence lengths; learned positional embeddings gave nearly identical results, but the sinusoidal version was preferred for its extrapolation potential (page 6; page 9).\n"
+      "The model uses fixed sinusoidal positional encodings—sine and cosine functions at different frequencies—added to the input embeddings and matching the embedding dimension (d_model) (page 6). The authors chose this scheme because it lets the model easily attend by relative positions (since PEpos+k is a linear function of PEpos) and may allow extrapolation to sequence lengths longer than those seen in training (page 6). They also found learned positional embeddings performed nearly identically but retained the sinusoidal version for its extrapolation advantages (pages 6, 9).\n"
      ]
     }
    ],
@@ -688,7 +728,8 @@
     "\n",
     "Here the vectors live in a Python list, which is fine for one paper. In production you write them to a\n",
     "vector store and search there. Transform's output already carries the text, vector and page metadata\n",
-    "per chunk, so it maps onto whatever database you use."
+    "per chunk, so it maps onto whatever database you use. See\n",
+    "[destinations](https://docs.unstructured.io/pipelines/destinations/overview)."
    ]
   },
   {
@@ -715,10 +756,10 @@
    "id": "cell-24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:38:40.602939Z",
-     "iopub.status.busy": "2026-07-27T23:38:40.602666Z",
-     "iopub.status.idle": "2026-07-27T23:39:28.461852Z",
-     "shell.execute_reply": "2026-07-27T23:39:28.461197Z"
+     "iopub.execute_input": "2026-07-28T01:53:29.111681Z",
+     "iopub.status.busy": "2026-07-28T01:53:29.111374Z",
+     "iopub.status.idle": "2026-07-28T01:54:07.735814Z",
+     "shell.execute_reply": "2026-07-28T01:54:07.734841Z"
     }
    },
    "outputs": [
@@ -728,36 +769,36 @@
      "text": [
       "{\n",
       "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n",
-      "  \"title\": \"Transformer Base Model Architecture and Training Configuration\",\n",
+      "  \"title\": \"Transformer Base Model Configuration\",\n",
       "  \"type\": \"object\",\n",
       "  \"properties\": {\n",
-      "    \"base_model_name\": {\n",
+      "    \"model_name\": {\n",
       "      \"type\": \"string\",\n",
-      "      \"description\": \"Name of the base model configuration\"\n",
+      "      \"description\": \"Name of the model architecture\"\n",
       "    },\n",
       "    \"architecture\": {\n",
       "      \"type\": \"string\",\n",
-      "      \"description\": \"Model architecture type\"\n",
+      "      \"description\": \"Type of neural network architecture\"\n",
       "    },\n",
       "    \"parameter_count\": {\n",
-      "      \"type\": \"number\",\n",
+      "      \"type\": \"integer\",\n",
       "      \"description\": \"Total number of model parameters in millions\"\n",
       "    },\n",
       "    \"vocab_size\": {\n",
       "      \"type\": \"integer\",\n",
-      "      \"description\": \"Size of the vocabulary\"\n",
+      "      \"description\": \"Size of the vocabulary for tokenization\"\n",
       "    },\n",
       "    \"tokenizer\": {\n",
       "      \"type\": \"string\",\n",
       "      \"description\": \"Tokenization method used\"\n",
       "    },\n",
-      "    \"num_layers\": {\n",
-      "      \"type\": \"integer\",\n",
-      "      \"description\": \"Number of encoder and decoder layers (N)\"\n",
+      "    \"optimizer\": {\n",
+      "      \"type\": \"string\",\n",
+      "      \"description\": \"Optimization algorithm used for training\"\n",
       "    },\n",
-      "    \"hidden_size\": {\n",
+      "    \"learning_rate_warmup_steps\": {\n",
       "      \"type\": \"integer\",\n",
-      "      \"description\": \"Dimensi\n"
+      "      \"description\": \"N\n"
      ]
     }
    ],
@@ -787,10 +828,10 @@
    "id": "cell-26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-27T23:39:28.464528Z",
-     "iopub.status.busy": "2026-07-27T23:39:28.464335Z",
-     "iopub.status.idle": "2026-07-27T23:40:33.490952Z",
-     "shell.execute_reply": "2026-07-27T23:40:33.490156Z"
+     "iopub.execute_input": "2026-07-28T01:54:07.739189Z",
+     "iopub.status.busy": "2026-07-28T01:54:07.738942Z",
+     "iopub.status.idle": "2026-07-28T01:55:30.679682Z",
+     "shell.execute_reply": "2026-07-28T01:55:30.678036Z"
     }
    },
    "outputs": [
@@ -799,36 +840,30 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "  \"filename\": \"1706-aabb8fdd.03762\",\n",
+      "  \"filename\": \"1706-27779320.03762\",\n",
       "  \"filetype\": \"application/pdf\",\n",
-      "  \"processed_date_utc\": \"2026-07-27T23:39:40.200473Z\",\n",
-      "  \"source_file_uri\": \"u10d://output/781a7d0f-ed2e-4f0c-af26-a562e0115505_1706-aabb8fdd.json\",\n",
+      "  \"processed_date_utc\": \"2026-07-28T01:54:18.224869Z\",\n",
+      "  \"source_file_uri\": \"u10d://output/539b9ef7-65c6-41e3-99d5-57b57f15bdd8_1706-27779320.json\",\n",
       "  \"extracted_data\": {\n",
-      "    \"base_model_name\": \"Transformer (base)\",\n",
+      "    \"model_name\": \"Transformer\",\n",
       "    \"architecture\": \"Transformer\",\n",
       "    \"parameter_count\": 65,\n",
       "    \"vocab_size\": 37000,\n",
       "    \"tokenizer\": \"byte-pair encoding\",\n",
-      "    \"num_layers\": 6,\n",
-      "    \"hidden_size\": 512,\n",
-      "    \"attention_heads\": 8,\n",
-      "    \"feedforward_size\": 2048,\n",
-      "    \"attention_key_size\": 64,\n",
-      "    \"attention_value_size\": 64,\n",
-      "    \"positional_encoding\": \"sinusoidal\",\n",
+      "    \"optimizer\": \"Adam\",\n",
+      "    \"learning_rate_warmup_steps\": 4000,\n",
+      "    \"batch_size_tokens\": 25000,\n",
+      "    \"training_steps\": 100000,\n",
+      "    \"training_hardware\": \"8 NVIDIA P100 GPUs\",\n",
       "    \"dropout\": 0.1,\n",
       "    \"label_smoothing\": 0.1,\n",
-      "    \"optimizer\": \"Adam\",\n",
-      "    \"beta1\": 0.9,\n",
-      "    \"beta2\": 0.98,\n",
-      "    \"epsilon\": 1e-09,\n",
-      "    \"lr_schedule\": \"d_model^(-0.5) \\u00b7 min(step_num^(-0.5), step_num \\u00b7 warmup_steps^(-1.5))\",\n",
-      "    \"warmup_steps\": 4000,\n",
-      "    \"training_steps\": 100000,\n",
-      "    \"batch_size_tokens\": 25000,\n",
-      "    \"training_data_description\": \"WMT 2014 English-German dataset consisting of about 4.5 million sentence pairs with shared source-target vocabulary using byte-pair encoding\",\n",
-      "    \"hardware\": \"one machine with 8 NVIDIA P100 GPUs\",\n",
-      "    \"training_time\": \"12 hours\"\n",
+      "    \"dataset_name\": \"WMT 2014 English-German\",\n",
+      "    \"model_dimension\": 512,\n",
+      "    \"num_layers\": 6,\n",
+      "    \"num_attention_heads\": 8,\n",
+      "    \"feedforward_dimension\": 2048,\n",
+      "    \"attention_key_dimension\": 64,\n",
+      "    \"attention_value_dimension\": 64\n",
       "  }\n",
       "}\n"
      ]
@@ -893,7 +928,7 @@
     "\n",
     "One thing this is not for: if you need a scheduled, continuous sync from a source to a destination\n",
     "across thousands of documents, that is Unstructured\n",
-    "[Pipelines](https://docs.unstructured.io/pipelines/overview), a different product. [Reach out](https://unstructured.io/product?modal=contact-sales) to our team to learn more."
+    "[Pipelines](https://docs.unstructured.io/pipelines/overview), a different product."
    ]
   },
   {
@@ -921,7 +956,7 @@
     "[chunking](https://docs.unstructured.io/concepts/chunking),\n",
     "[embedding](https://docs.unstructured.io/concepts/embedding), the\n",
     "[data extractor](https://docs.unstructured.io/concepts/structured-data-extractor/data-extractor), and\n",
-    "the [supported file types](https://docs.unstructured.io/transform/supported-file-types).\n",
+    "the [65+ supported file types](https://docs.unstructured.io/pipelines/supported-file-types).\n",
     "\n",
     "**Ready to point this at your own documents?** Swap the URL at the top for an invoice, a contract, a\n",
     "deck, or a folder of mixed formats, and ask for what you need.\n",
@@ -948,7 +983,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/Getting_Started_with_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/Getting_Started_with_Unstructured_Transform_MCP.ipynb
@@ -1,0 +1,956 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Unstructured Transform\n",
+    "\n",
+    "You have a PDF. You hand it to a language model and ask about the table on page 8. What comes back is\n",
+    "a shapeless run of digits, because somewhere between the page and the prompt the rows and columns\n",
+    "stopped existing.\n",
+    "\n",
+    "So you go and build a parsing pipeline. Layout detection, OCR for the scanned pages, something to keep\n",
+    "tables intact, chunking, embeddings. Weeks later you have infrastructure to maintain and you still\n",
+    "have not written the feature you wanted.\n",
+    "\n",
+    "**Unstructured Transform is that pipeline, hosted, driven by a sentence.** Point it at a file and it\n",
+    "runs as many of these stages as your request needs:\n",
+    "\n",
+    "| Stage | What it does |\n",
+    "| --- | --- |\n",
+    "| **Parse** | Reads the raw file into clean, structured elements |\n",
+    "| **Enrich** | Adds AI passes: image descriptions, OCR cleanup, tables to HTML |\n",
+    "| **Chunk** | Splits content into retrieval-sized pieces |\n",
+    "| **Embed** | Turns those chunks into vectors for semantic search |\n",
+    "| **Extract** | Pulls named fields straight out of the document as JSON |\n",
+    "\n",
+    "You never configure any of it by hand. You say what you want and it assembles the right stages.\n",
+    "\n",
+    "By the end of this notebook you will have built:\n",
+    "\n",
+    "- A question-answering system over a PDF with no vector database at all\n",
+    "- The same thing with embeddings, for when you outgrow that\n",
+    "- A structured extractor that turns the document into database rows\n",
+    "\n",
+    "We will use the *\"Attention Is All You Need\"* paper throughout, because its tables and notation are\n",
+    "exactly what naive text extraction destroys.\n",
+    "\n",
+    "One thing worth knowing before you start: you do not need a notebook for any of this. Transform is an\n",
+    "MCP server, so it plugs straight into **Claude Code, Codex, or Cursor**. You add it once, sign in, and\n",
+    "then just talk to it. See the [setup guide](https://docs.unstructured.io/transform/install/overview).\n",
+    "We are using Python here because it makes every step visible.\n",
+    "\n",
+    "Let's dive in!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:32:13.372184Z",
+     "iopub.status.busy": "2026-07-27T23:32:13.372076Z",
+     "iopub.status.idle": "2026-07-27T23:32:14.919070Z",
+     "shell.execute_reply": "2026-07-27T23:32:14.918433Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pip install -U openai requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "You need two keys.\n",
+    "\n",
+    "For Unstructured, [sign up here](https://unstructured.io/?modal=try-for-free), log in, and copy your\n",
+    "API key. You get 15,000 pages free every month, and this notebook uses about 45 of them.\n",
+    "\n",
+    "For OpenAI, grab a key from [the API keys page](https://platform.openai.com/api-keys)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:32:14.921215Z",
+     "iopub.status.busy": "2026-07-27T23:32:14.921059Z",
+     "iopub.status.idle": "2026-07-27T23:32:15.322197Z",
+     "shell.execute_reply": "2026-07-27T23:32:15.321875Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/ajaykrishnan/Documents/Work/mcpalooza/.venv-tutorials/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import math\n",
+    "import os\n",
+    "import re\n",
+    "import time\n",
+    "from getpass import getpass\n",
+    "\n",
+    "import requests\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "if \"OPENAI_API_KEY\" not in os.environ:\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass(\"OpenAI API key: \")\n",
+    "if \"UNSTRUCTURED_API_KEY\" not in os.environ:\n",
+    "    os.environ[\"UNSTRUCTURED_API_KEY\"] = getpass(\"Unstructured API key: \")\n",
+    "\n",
+    "client = OpenAI()\n",
+    "\n",
+    "TRANSFORM_MCP_URL = \"https://mcp.transform.unstructured.io/\"\n",
+    "MODEL = \"gpt-5\"\n",
+    "PDF_URL = \"https://arxiv.org/pdf/1706.03762\"  # \"Attention Is All You Need\"\n",
+    "DOC_PATH = \"attention.md\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "Now we connect the model to Transform. The Responses API can call a remote MCP server directly, so we\n",
+    "describe the server as a tool and the model does the rest.\n",
+    "\n",
+    "One piece of plumbing is needed because we are in Python. Transform processes files asynchronously, so\n",
+    "the model has to wait while a job runs, and a hosted tool cannot pause itself. We give it a local\n",
+    "`wait_seconds` function it can call to do that, and `run()` below handles the back and forth.\n",
+    "\n",
+    "If you work in Claude Code, Codex or Cursor, skip past this. Your agent already handles all of it, and\n",
+    "you would just say \"parse this PDF\" and get the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:32:15.323594Z",
+     "iopub.status.busy": "2026-07-27T23:32:15.323522Z",
+     "iopub.status.idle": "2026-07-27T23:32:15.326927Z",
+     "shell.execute_reply": "2026-07-27T23:32:15.326716Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def transform_mcp_tool():\n",
+    "    \"\"\"Describe the Transform MCP server as a tool the model can call.\"\"\"\n",
+    "    return {\n",
+    "        \"type\": \"mcp\",\n",
+    "        \"server_label\": \"unstructured_transform\",\n",
+    "        \"server_url\": TRANSFORM_MCP_URL,\n",
+    "        \"require_approval\": \"never\",\n",
+    "        \"headers\": {\"Authorization\": f\"Bearer {os.environ['UNSTRUCTURED_API_KEY']}\"},\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def wait_seconds(seconds):\n",
+    "    \"\"\"Let the model pace itself while a Transform job runs.\"\"\"\n",
+    "    time.sleep(seconds)\n",
+    "    return f\"Waited {seconds} seconds.\"\n",
+    "\n",
+    "\n",
+    "WAIT_TOOL = {\n",
+    "    \"type\": \"function\",\n",
+    "    \"name\": \"wait_seconds\",\n",
+    "    \"description\": \"Wait the given number of seconds before checking the job status again.\",\n",
+    "    \"parameters\": {\n",
+    "        \"type\": \"object\",\n",
+    "        \"properties\": {\"seconds\": {\"type\": \"integer\"}},\n",
+    "        \"required\": [\"seconds\"],\n",
+    "        \"additionalProperties\": False,\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def run(instruction):\n",
+    "    \"\"\"Ask Transform for something. Returns the model's reply and the job results.\"\"\"\n",
+    "    tools = [transform_mcp_tool(), WAIT_TOOL]\n",
+    "    resp = client.responses.create(model=MODEL, tools=tools, input=instruction)\n",
+    "    results = {}\n",
+    "\n",
+    "    for _ in range(40):\n",
+    "        for item in resp.output:\n",
+    "            if item.type == \"mcp_call\" and item.output:\n",
+    "                try:\n",
+    "                    results[item.name] = json.loads(item.output)\n",
+    "                except ValueError:\n",
+    "                    pass\n",
+    "        calls = [i for i in resp.output if i.type == \"function_call\"]\n",
+    "        if not calls:\n",
+    "            break\n",
+    "        outputs = [\n",
+    "            {\n",
+    "                \"type\": \"function_call_output\",\n",
+    "                \"call_id\": c.call_id,\n",
+    "                \"output\": wait_seconds(**json.loads(c.arguments)),\n",
+    "            }\n",
+    "            for c in calls\n",
+    "        ]\n",
+    "        resp = client.responses.create(\n",
+    "            model=MODEL, tools=tools, previous_response_id=resp.id, input=outputs\n",
+    "        )\n",
+    "\n",
+    "    # Download links carry a long signed token that expires within the hour. Shorten\n",
+    "    # it so the printed reply stays readable.\n",
+    "    reply = re.sub(r\"\\?token=[\\w.\\-]+\", \"?token=...\", resp.output_text)\n",
+    "    return reply, results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "## 1. Answer questions about a document, with no vector database\n",
+    "\n",
+    "Before you stand up a vector store, try the version that needs no infrastructure.\n",
+    "\n",
+    "Parse the document once into markdown. Then give the model two tools, a search and a line reader, and\n",
+    "let it navigate the file the way you would navigate an unfamiliar codebase: search for the relevant\n",
+    "part, read around the hit, answer from what you read.\n",
+    "\n",
+    "First, the parse. Notice that we just ask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:32:15.328033Z",
+     "iopub.status.busy": "2026-07-27T23:32:15.327969Z",
+     "iopub.status.idle": "2026-07-27T23:37:12.369951Z",
+     "shell.execute_reply": "2026-07-27T23:37:12.368958Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I parsed the PDF using the hi_res strategy with enrichments (image_description, table_to_html, generative_ocr) to handle tables and figures well. The job is complete.\n",
+      "\n",
+      "Download the markdown file:\n",
+      "https://mcp.transform.unstructured.io/output/781a7d0f-ed2e-4f0c-af26-a562e0115505_1706-aabb8fdd_md.md?token=...\n",
+      "\n",
+      "One‑liner to save it locally:\n",
+      "curl -fSs -o attention_is_all_you_need.md 'https://mcp.transform.unstructured.io/output/781a7d0f-ed2e-4f0c-af26-a562e0115505_1706-aabb8fdd_md.md?token=...'\n",
+      "\n",
+      "Notes:\n",
+      "- Link expires: 2026-07-28T00:36:59Z. If it lapses, I can re-mint it instantly.\n",
+      "- Parse output ref (for further processing/extraction without re-parsing): u10d://output/781a7d0f-ed2e-4f0c-af26-a562e0115505_1706-aabb8fdd.json\n",
+      "\n",
+      "If you want me to paste the markdown content here, please download the file and upload/share a readable path, and I’ll return its contents.\n"
+     ]
+    }
+   ],
+   "source": [
+    "reply, results = run(\n",
+    "    f\"Parse the PDF at {PDF_URL} into markdown using the Unstructured Transform tools. \"\n",
+    "    \"It is a research paper full of tables and figures, so choose the parse approach that \"\n",
+    "    \"handles those well. Wait for the job to finish, then give me the markdown.\"\n",
+    ")\n",
+    "print(reply)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "Transform returns the output as a download link rather than dumping a whole document into the model's\n",
+    "context. Let's fetch it and look at what happened to the results table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:37:12.374885Z",
+     "iopub.status.busy": "2026-07-27T23:37:12.374750Z",
+     "iopub.status.idle": "2026-07-27T23:37:13.027237Z",
+     "shell.execute_reply": "2026-07-27T23:37:13.026672Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "44,848 characters\n",
+      "\n",
+      "<table><thead><tr><th>Layer Type</th><th>Complexity per Layer</th><th>Sequential Operations</th><th>Maximum Path Length</th></tr></thead><tbody><tr><td>Self-Attention</td><td>O(n² · d)</td><td>O(1)</td><td>O(1)</td></tr><tr><td>Recurrent</td><td>O(n · d²)</td><td>O(n)</td><td>O(n)</td></tr><tr><td>Convolutional</td><td>O(k · n · d²)</td><td>O(1)</td><td>O(log_k(n))</td></tr><tr><td>Self-Attention (restricted)</td><td>O(r · n · d)</td><td>O(1)</td><td>O(n/r)</td></tr></tbody></table>\n",
+      "\n",
+      "# 3.5 Positional Encoding\n",
+      "\n",
+      "Since our model contains no recurrence and no convolution, in order for the model to make use of the order of the sequence, we must inject some information about the relative or absolu\n"
+     ]
+    }
+   ],
+   "source": [
+    "files = results[\"get_job_results\"][\"files\"]\n",
+    "markdown = requests.get(files[0][\"download_url\"], timeout=120).text\n",
+    "open(DOC_PATH, \"w\", encoding=\"utf-8\").write(markdown)\n",
+    "\n",
+    "parsed_doc = files[0][\"output_ref\"]  # reusable handle, we come back to this twice\n",
+    "print(f\"{len(markdown):,} characters\\n\")\n",
+    "\n",
+    "start = markdown.find(\"<table\")\n",
+    "print(markdown[start : start + 700])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "The table came back as HTML, with its rows and columns intact. That is the difference between a table\n",
+    "you can query and a pile of loose numbers, and it is what makes the second question below possible.\n",
+    "\n",
+    "Now the two tools. This is the entire retrieval layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:37:13.029368Z",
+     "iopub.status.busy": "2026-07-27T23:37:13.029211Z",
+     "iopub.status.idle": "2026-07-27T23:37:13.034612Z",
+     "shell.execute_reply": "2026-07-27T23:37:13.034187Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def search_document(query):\n",
+    "    \"\"\"Find lines in the document containing a phrase.\"\"\"\n",
+    "    lines = open(DOC_PATH, encoding=\"utf-8\").read().splitlines()\n",
+    "    hits = [f\"L{i + 1}: {line}\" for i, line in enumerate(lines) if query.lower() in line.lower()]\n",
+    "    return \"\\n\".join(hits[:25]) if hits else \"No matches.\"\n",
+    "\n",
+    "\n",
+    "def read_lines(start, end):\n",
+    "    \"\"\"Read an inclusive range of lines from the document.\"\"\"\n",
+    "    lines = open(DOC_PATH, encoding=\"utf-8\").read().splitlines()\n",
+    "    start, end = max(1, int(start)), min(len(lines), int(end))\n",
+    "    return \"\\n\".join(f\"L{i}: {lines[i - 1]}\" for i in range(start, end + 1))\n",
+    "\n",
+    "\n",
+    "TOOL_FUNCS = {\"search_document\": search_document, \"read_lines\": read_lines}\n",
+    "\n",
+    "TOOLS = [\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"name\": \"search_document\",\n",
+    "        \"description\": \"Search the document for a phrase. Returns matching lines with line numbers.\",\n",
+    "        \"parameters\": {\n",
+    "            \"type\": \"object\",\n",
+    "            \"properties\": {\"query\": {\"type\": \"string\"}},\n",
+    "            \"required\": [\"query\"],\n",
+    "            \"additionalProperties\": False,\n",
+    "        },\n",
+    "    },\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"name\": \"read_lines\",\n",
+    "        \"description\": \"Read an inclusive range of lines from the document.\",\n",
+    "        \"parameters\": {\n",
+    "            \"type\": \"object\",\n",
+    "            \"properties\": {\"start\": {\"type\": \"integer\"}, \"end\": {\"type\": \"integer\"}},\n",
+    "            \"required\": [\"start\", \"end\"],\n",
+    "            \"additionalProperties\": False,\n",
+    "        },\n",
+    "    },\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:37:13.036227Z",
+     "iopub.status.busy": "2026-07-27T23:37:13.036084Z",
+     "iopub.status.idle": "2026-07-27T23:37:13.039731Z",
+     "shell.execute_reply": "2026-07-27T23:37:13.039341Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "SYSTEM = (\n",
+    "    \"You answer questions about a document you can only reach through the search_document and \"\n",
+    "    \"read_lines tools. Search to find the relevant part, read it, then answer from it alone. \"\n",
+    "    \"End with a line: 'Source: <the section or table you used>'.\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def ask(question):\n",
+    "    \"\"\"Answer a question by searching and reading the parsed document.\"\"\"\n",
+    "    resp = client.responses.create(\n",
+    "        model=MODEL,\n",
+    "        tools=TOOLS,\n",
+    "        input=[\n",
+    "            {\"role\": \"system\", \"content\": SYSTEM},\n",
+    "            {\"role\": \"user\", \"content\": question},\n",
+    "        ],\n",
+    "    )\n",
+    "    for _ in range(8):\n",
+    "        calls = [i for i in resp.output if i.type == \"function_call\"]\n",
+    "        if not calls:\n",
+    "            break\n",
+    "        outputs = [\n",
+    "            {\n",
+    "                \"type\": \"function_call_output\",\n",
+    "                \"call_id\": c.call_id,\n",
+    "                \"output\": TOOL_FUNCS[c.name](**json.loads(c.arguments)),\n",
+    "            }\n",
+    "            for c in calls\n",
+    "        ]\n",
+    "        resp = client.responses.create(\n",
+    "            model=MODEL, tools=TOOLS, previous_response_id=resp.id, input=outputs\n",
+    "        )\n",
+    "    return resp.output_text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:37:13.041439Z",
+     "iopub.status.busy": "2026-07-27T23:37:13.041339Z",
+     "iopub.status.idle": "2026-07-27T23:37:23.345343Z",
+     "shell.execute_reply": "2026-07-27T23:37:23.344688Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "They use fixed sinusoidal positional encodings (sine and cosine functions of different frequencies) added to the input embeddings. The authors chose this because:\n",
+      "- It should let the model easily learn relative positions (for any fixed offset k, PEpos+k is a linear function of PEpos).\n",
+      "- It may extrapolate to sequence lengths longer than those seen in training, while performing similarly to learned positional embeddings.\n",
+      "\n",
+      "Source: Section 3.5 Positional Encoding\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ask(\"What positional encoding does the model use, and why did the authors choose it?\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:37:23.348650Z",
+     "iopub.status.busy": "2026-07-27T23:37:23.348389Z",
+     "iopub.status.idle": "2026-07-27T23:37:33.177462Z",
+     "shell.execute_reply": "2026-07-27T23:37:33.176730Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "41.29 BLEU\n",
+      "\n",
+      "Source: Table 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ask(\"What BLEU score did the ConvS2S Ensemble model reach on English-to-French?\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-15",
+   "metadata": {},
+   "source": [
+    "That second number, 41.29, appears nowhere in the paper's prose. It exists only inside a cell of the\n",
+    "results table, so being able to answer the question at all is the proof that the table survived\n",
+    "parsing.\n",
+    "\n",
+    "No vector database, no chunking decisions, no index to keep in sync, and every answer cites where it\n",
+    "came from. For a handful of documents this is often all you need.\n",
+    "\n",
+    "It stops scaling when search stops finding things. Grep either hits or it does not, so a user who\n",
+    "phrases a question nothing like the text gets nothing, and there is no way to rank results across a\n",
+    "thousand documents. That is what embeddings fix."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-16",
+   "metadata": {},
+   "source": [
+    "## 2. Add embeddings for semantic search\n",
+    "\n",
+    "Embedding turns each chunk into a vector, a numeric fingerprint of its meaning, so a search matches on\n",
+    "meaning instead of characters.\n",
+    "\n",
+    "Transform chunks and embeds for you, with OpenAI, Azure OpenAI, or Bedrock models (Titan and Cohere).\n",
+    "We will use `text-embedding-3-small`.\n",
+    "\n",
+    "We already parsed this paper, so we hand Transform that same handle instead of paying to read the PDF\n",
+    "again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cell-17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:37:33.180335Z",
+     "iopub.status.busy": "2026-07-27T23:37:33.180084Z",
+     "iopub.status.idle": "2026-07-27T23:38:31.956502Z",
+     "shell.execute_reply": "2026-07-27T23:38:31.955822Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "EMBED_MODEL = \"text-embedding-3-small\"\n",
+    "\n",
+    "reply, results = run(\n",
+    "    f\"Take the already-parsed document at {parsed_doc} and chunk it by title into pieces of at \"\n",
+    "    f\"most 800 characters, then embed those chunks with OpenAI {EMBED_MODEL}. \"\n",
+    "    \"Wait for the job, then give me the results as JSON.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cell-18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:38:31.961183Z",
+     "iopub.status.busy": "2026-07-27T23:38:31.960865Z",
+     "iopub.status.idle": "2026-07-27T23:38:33.406124Z",
+     "shell.execute_reply": "2026-07-27T23:38:33.405733Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "71 chunks, 1536 dimensions each\n"
+     ]
+    }
+   ],
+   "source": [
+    "files = results[\"get_job_results\"][\"files\"]\n",
+    "elements = requests.get(files[0][\"download_url\"], timeout=120).json()\n",
+    "\n",
+    "chunks = [\n",
+    "    {\n",
+    "        \"text\": e[\"text\"],\n",
+    "        \"vector\": e[\"embeddings\"],\n",
+    "        \"page\": (e.get(\"metadata\") or {}).get(\"page_number\"),\n",
+    "    }\n",
+    "    for e in elements\n",
+    "    if e.get(\"embeddings\")\n",
+    "]\n",
+    "\n",
+    "print(f\"{len(chunks)} chunks, {len(chunks[0]['vector'])} dimensions each\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-19",
+   "metadata": {},
+   "source": [
+    "Each chunk now carries a vector. The search is cosine similarity, which is a few lines of plain Python.\n",
+    "\n",
+    "The one rule: embed your question with the same model you embedded the document with, or the vectors\n",
+    "are not comparable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:38:33.407960Z",
+     "iopub.status.busy": "2026-07-27T23:38:33.407825Z",
+     "iopub.status.idle": "2026-07-27T23:38:34.003050Z",
+     "shell.execute_reply": "2026-07-27T23:38:34.002609Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[page 6] 3.5 Positional Encoding\n",
+      "\n",
+      "Since our model contains no recurrence and no convolution, in order for the...\n",
+      "[page 6] where pos is the position and i is the dimension. That is, each dimension of the positional encoding...\n",
+      "[page 9] In Table 3 rows (B), we observe that reducing the attention key size dk hurts model quality. This su...\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cosine(a, b):\n",
+    "    \"\"\"Similarity between two vectors.\"\"\"\n",
+    "    dot = sum(x * y for x, y in zip(a, b))\n",
+    "    return dot / (math.sqrt(sum(x * x for x in a)) * math.sqrt(sum(y * y for y in b)))\n",
+    "\n",
+    "\n",
+    "def search(question, k=3): # extremely vanilla function don't mind\n",
+    "    \"\"\"Find the chunks closest in meaning to the question.\"\"\"\n",
+    "    q = client.embeddings.create(model=EMBED_MODEL, input=question).data[0].embedding\n",
+    "    return sorted(chunks, key=lambda c: cosine(q, c[\"vector\"]), reverse=True)[:k]\n",
+    "\n",
+    "\n",
+    "question = \"What positional encoding does the model use, and why did the authors choose it?\"\n",
+    "\n",
+    "hits = search(question)\n",
+    "for hit in hits:\n",
+    "    print(f\"[page {hit['page']}] {hit['text'][:100].strip()}...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cell-21",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:38:34.005003Z",
+     "iopub.status.busy": "2026-07-27T23:38:34.004861Z",
+     "iopub.status.idle": "2026-07-27T23:38:40.598878Z",
+     "shell.execute_reply": "2026-07-27T23:38:40.597995Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The model uses sinusoidal positional encodings—sine and cosine functions at different frequencies—added to the input embeddings. The authors chose this because the sinusoids let the model learn relative positions (PEpos+k is a linear function of PEpos) and may enable extrapolation to longer sequence lengths; learned positional embeddings gave nearly identical results, but the sinusoidal version was preferred for its extrapolation potential (page 6; page 9).\n"
+     ]
+    }
+   ],
+   "source": [
+    "context = \"\\n\\n\".join(f\"(page {h['page']}) {h['text']}\" for h in hits)\n",
+    "\n",
+    "answer = client.responses.create(\n",
+    "    model=MODEL,\n",
+    "    input=[\n",
+    "        {\"role\": \"system\", \"content\": \"Answer from the passages below and cite the page numbers.\"},\n",
+    "        {\"role\": \"user\", \"content\": f\"Passages:\\n{context}\\n\\nQuestion: {question}\"},\n",
+    "    ],\n",
+    ")\n",
+    "print(answer.output_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-22",
+   "metadata": {},
+   "source": [
+    "Same answer as before, reached by ranking rather than searching for a string. The three passages it\n",
+    "retrieved cost a fraction of the context that reading through the file did.\n",
+    "\n",
+    "Here the vectors live in a Python list, which is fine for one paper. In production you write them to a\n",
+    "vector store and search there. Transform's output already carries the text, vector and page metadata\n",
+    "per chunk, so it maps onto whatever database you use."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-23",
+   "metadata": {},
+   "source": [
+    "## 3. Pull named fields out as JSON\n",
+    "\n",
+    "The first two features answered questions. Sometimes you do not want an answer, you want values: the\n",
+    "same fields, out of every document, in a shape you can put in a database. Invoice numbers and line\n",
+    "items. Contract parties and dates. Or, here, the settings you would need to reproduce a paper.\n",
+    "\n",
+    "Imagine you have two hundred of these papers and you want one table comparing how each model was\n",
+    "trained. Asking questions does not scale to that. Extracting fields does.\n",
+    "\n",
+    "Extraction works on the parsed document, so we reuse that same handle a third time. And if you do not\n",
+    "have a schema yet, Transform will write one for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "cell-24",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:38:40.602939Z",
+     "iopub.status.busy": "2026-07-27T23:38:40.602666Z",
+     "iopub.status.idle": "2026-07-27T23:39:28.461852Z",
+     "shell.execute_reply": "2026-07-27T23:39:28.461197Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n",
+      "  \"title\": \"Transformer Base Model Architecture and Training Configuration\",\n",
+      "  \"type\": \"object\",\n",
+      "  \"properties\": {\n",
+      "    \"base_model_name\": {\n",
+      "      \"type\": \"string\",\n",
+      "      \"description\": \"Name of the base model configuration\"\n",
+      "    },\n",
+      "    \"architecture\": {\n",
+      "      \"type\": \"string\",\n",
+      "      \"description\": \"Model architecture type\"\n",
+      "    },\n",
+      "    \"parameter_count\": {\n",
+      "      \"type\": \"number\",\n",
+      "      \"description\": \"Total number of model parameters in millions\"\n",
+      "    },\n",
+      "    \"vocab_size\": {\n",
+      "      \"type\": \"integer\",\n",
+      "      \"description\": \"Size of the vocabulary\"\n",
+      "    },\n",
+      "    \"tokenizer\": {\n",
+      "      \"type\": \"string\",\n",
+      "      \"description\": \"Tokenization method used\"\n",
+      "    },\n",
+      "    \"num_layers\": {\n",
+      "      \"type\": \"integer\",\n",
+      "      \"description\": \"Number of encoder and decoder layers (N)\"\n",
+      "    },\n",
+      "    \"hidden_size\": {\n",
+      "      \"type\": \"integer\",\n",
+      "      \"description\": \"Dimensi\n"
+     ]
+    }
+   ],
+   "source": [
+    "reply, results = run(\n",
+    "    f\"Use suggest_extraction_schema_for_file on {parsed_doc} to draft a JSON extraction schema \"\n",
+    "    \"for this paper. Keep it small and flat: just the base model's architecture and training \"\n",
+    "    \"settings, one value per field, the kind of thing you would need to reproduce it. \"\n",
+    "    \"Then report the schema.\"\n",
+    ")\n",
+    "\n",
+    "schema = json.loads(results[\"suggest_extraction_schema_for_file\"][\"schema\"])\n",
+    "print(json.dumps(schema, indent=2)[:900])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-25",
+   "metadata": {},
+   "source": [
+    "Now extract with that schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cell-26",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-27T23:39:28.464528Z",
+     "iopub.status.busy": "2026-07-27T23:39:28.464335Z",
+     "iopub.status.idle": "2026-07-27T23:40:33.490952Z",
+     "shell.execute_reply": "2026-07-27T23:40:33.490156Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"filename\": \"1706-aabb8fdd.03762\",\n",
+      "  \"filetype\": \"application/pdf\",\n",
+      "  \"processed_date_utc\": \"2026-07-27T23:39:40.200473Z\",\n",
+      "  \"source_file_uri\": \"u10d://output/781a7d0f-ed2e-4f0c-af26-a562e0115505_1706-aabb8fdd.json\",\n",
+      "  \"extracted_data\": {\n",
+      "    \"base_model_name\": \"Transformer (base)\",\n",
+      "    \"architecture\": \"Transformer\",\n",
+      "    \"parameter_count\": 65,\n",
+      "    \"vocab_size\": 37000,\n",
+      "    \"tokenizer\": \"byte-pair encoding\",\n",
+      "    \"num_layers\": 6,\n",
+      "    \"hidden_size\": 512,\n",
+      "    \"attention_heads\": 8,\n",
+      "    \"feedforward_size\": 2048,\n",
+      "    \"attention_key_size\": 64,\n",
+      "    \"attention_value_size\": 64,\n",
+      "    \"positional_encoding\": \"sinusoidal\",\n",
+      "    \"dropout\": 0.1,\n",
+      "    \"label_smoothing\": 0.1,\n",
+      "    \"optimizer\": \"Adam\",\n",
+      "    \"beta1\": 0.9,\n",
+      "    \"beta2\": 0.98,\n",
+      "    \"epsilon\": 1e-09,\n",
+      "    \"lr_schedule\": \"d_model^(-0.5) \\u00b7 min(step_num^(-0.5), step_num \\u00b7 warmup_steps^(-1.5))\",\n",
+      "    \"warmup_steps\": 4000,\n",
+      "    \"training_steps\": 100000,\n",
+      "    \"batch_size_tokens\": 25000,\n",
+      "    \"training_data_description\": \"WMT 2014 English-German dataset consisting of about 4.5 million sentence pairs with shared source-target vocabulary using byte-pair encoding\",\n",
+      "    \"hardware\": \"one machine with 8 NVIDIA P100 GPUs\",\n",
+      "    \"training_time\": \"12 hours\"\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "reply, results = run(\n",
+    "    f\"Run an extraction job on {parsed_doc} using exactly this schema: {json.dumps(schema)}. \"\n",
+    "    \"Wait for it to finish, then give me the extracted data.\"\n",
+    ")\n",
+    "\n",
+    "print(json.dumps(results[\"get_job_results\"][\"files\"][0], indent=2)[:1800])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-27",
+   "metadata": {},
+   "source": [
+    "The paper's training setup, as fields. Run that over a folder of papers and you have your comparison\n",
+    "table. From here it is an `INSERT`, not a language problem.\n",
+    "\n",
+    "These values are scattered across the paper: the layer counts sit in a table, the optimizer settings in\n",
+    "a paragraph of section 5, the hardware in another. You did not have to know where any of them were.\n",
+    "\n",
+    "Notice each result arrives wrapped with its `filename` and `source_file_uri`. When you run a batch of\n",
+    "invoices through this, that is what tells you which record came from which document.\n",
+    "\n",
+    "One rule worth remembering: extraction can only find what the parse captured. Ask for fields that live\n",
+    "in a badly scanned table and you will get gaps, which is what the first two tips below are for."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-28",
+   "metadata": {},
+   "source": [
+    "## Tips\n",
+    "\n",
+    "Everything above used one plain instruction per step. Here are the ones worth knowing next, in the same\n",
+    "form. Just ask.\n",
+    "\n",
+    "**Documents that are mostly tables.** *\"Parse this at high resolution, give me the tables as HTML, and\n",
+    "add a description of each one.\"* HTML keeps the structure so your code can read a table as a table. The\n",
+    "description makes it findable, because a grid of numbers matches a natural-language question badly. Add\n",
+    "both and \"which quarter had the highest churn\" can actually find the right table.\n",
+    "\n",
+    "**Scanned, watermarked or handwritten pages.** *\"This scan is messy, clean the text up with generative\n",
+    "OCR.\"* A vision model re-reads the difficult blocks. This paper has an arXiv watermark printed sideways\n",
+    "down the margin, which parses as `3 2 0 2 g u A 2` one character at a time; generative OCR is what\n",
+    "turns that back into `arXiv:1706.03762v7 [cs.CL] 2 Aug 2023`.\n",
+    "\n",
+    "**Charts, diagrams and slide decks.** *\"Describe the images in this deck so we can use what is in\n",
+    "them.\"* By default a chart is just an image and your agent answers as though its contents do not exist.\n",
+    "Image descriptions put a summary of each figure into the output, so it becomes something the model can\n",
+    "reason over and cite.\n",
+    "\n",
+    "**Chunking that fits your documents.** *\"Re-chunk that same parse by page instead, and by\n",
+    "similarity.\"* Where you split matters as much as how you parse. Titles suit documents with real\n",
+    "headings, pages suit forms and slides, similarity suits text with no clean structure. Point Transform at\n",
+    "a parse you already ran and compare, rather than re-parsing each time.\n",
+    "\n",
+    "One thing this is not for: if you need a scheduled, continuous sync from a source to a destination\n",
+    "across thousands of documents, that is Unstructured\n",
+    "[Pipelines](https://docs.unstructured.io/pipelines/overview), a different product. [Reach out](https://unstructured.io/product?modal=contact-sales) to our team to learn more."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-29",
+   "metadata": {},
+   "source": [
+    "## Wrapping up\n",
+    "\n",
+    "We parsed one PDF and used it three ways:\n",
+    "\n",
+    "- Answered questions with nothing but a search and a line reader, and pulled a number out of a table\n",
+    "  that does not appear anywhere else in the document\n",
+    "- Chunked and embedded it for ranked semantic search, without re-parsing\n",
+    "- Extracted its training configuration into flat JSON, against a schema Transform wrote itself\n",
+    "\n",
+    "Same document, same three instructions in plain English, three different shapes of output. That is the\n",
+    "whole idea: you describe what you need and Transform assembles the pipeline.\n",
+    "\n",
+    "To go further, start with the [concepts overview](https://docs.unstructured.io/concepts/overview).\n",
+    "Everything here is one corner of it, and the interesting uses come from combining stages in ways no\n",
+    "tutorial will guess for you. Worth a look:\n",
+    "[partitioning strategies](https://docs.unstructured.io/concepts/partitioning),\n",
+    "[enrichments](https://docs.unstructured.io/concepts/enriching/overview),\n",
+    "[chunking](https://docs.unstructured.io/concepts/chunking),\n",
+    "[embedding](https://docs.unstructured.io/concepts/embedding), the\n",
+    "[data extractor](https://docs.unstructured.io/concepts/structured-data-extractor/data-extractor), and\n",
+    "the [supported file types](https://docs.unstructured.io/transform/supported-file-types).\n",
+    "\n",
+    "**Ready to point this at your own documents?** Swap the URL at the top for an invoice, a contract, a\n",
+    "deck, or a folder of mixed formats, and ask for what you need.\n",
+    "[Sign up for Unstructured](https://unstructured.io/?modal=try-for-free) if you have not already, and\n",
+    "come talk to us in the\n",
+    "[community Slack](https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-4399mep47-MfLsMuA6K9Dwy86BhNY1KA)\n",
+    "if you hit a document that still gives you trouble."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Getting_Started_with_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/Getting_Started_with_Unstructured_Transform_MCP.ipynb
@@ -59,7 +59,7 @@
    },
    "outputs": [],
    "source": [
-    "pip install -U openai requests"
+%pip install -U openai requests
    ]
   },
   {


### PR DESCRIPTION
## What

A getting-started notebook for the Unstructured Transform MCP server, built around one document (the *Attention Is All You Need* paper) and three things you can do with it.

Every Transform call is a plain-language instruction rather than a pipeline config, which is both simpler to read and closer to how the product is actually used.

## The three features

1. **Question answering with no vector database.** Parse once to markdown, then give the model a search tool and a line reader and let it navigate the file the way you would navigate an unfamiliar repo. The second question asks for a BLEU score that appears only inside a table cell (`41.29`), so answering it at all demonstrates that the table survived parsing.
2. **Embeddings for semantic search.** Chunk and embed with `text-embedding-3-small`, reusing the `output_ref` from step 1 so the PDF is not parsed twice. Cosine similarity in a few lines of plain Python, no extra dependencies.
3. **Structured extraction.** Ask Transform to draft a schema, then extract against that exact schema. Returns the paper's full training configuration as flat JSON: layer counts, optimizer settings, hardware, and training time, values that are scattered across a table and two different sections.

Closes with four tips in the same plain-language form (table-heavy documents, scanned or watermarked pages, charts and decks, chunking strategies) and links to the concepts docs.

## Notes

- Outputs are committed, so the notebook can be read without running it.
- Two dependencies, `openai` and `requests`. The similarity search is plain Python, so no numpy or pandas.
- Keys are read via `getpass`; nothing is hard-coded.
- Uses the current tool names (`start_transform_job`, `check_job_status`, `get_job_results`, `start_extraction_job`, `suggest_extraction_schema_for_file`).
- Notes up front that none of the Python plumbing is needed in Claude Code, Codex or Cursor, where you add the MCP server once and just talk to it.

## Verification

Executed end to end against the live server. All 15 code cells run with no errors, and the answers were checked against the paper: the positional-encoding explanation matches section 3.5, the BLEU figure matches Table 2, and all 26 extracted configuration fields are correct.