### PR TITLE
Update Transform free page allowance to current pricing

### DIFF
--- a/notebooks/Getting_Started_with_Unstructured_Transform_MCP.ipynb
+++ b/notebooks/Getting_Started_with_Unstructured_Transform_MCP.ipynb
@@ -115,7 +115,7 @@
     "You need two keys.\n",
     "\n",
     "For Unstructured, [sign up here](https://unstructured.io/?modal=try-for-free), log in, and copy your\n",
-    "API key. You get 15,000 pages free every month, and this notebook uses about 45 of them.\n",
+    "API key. Your account starts with 10,000 free pages, and this notebook uses about 45 of them.\n",
     "\n",
     "For OpenAI, grab a key from [the API keys page](https://platform.openai.com/api-keys)."
    ]


### PR DESCRIPTION
Pricing changed to 10,000 free pages at account start (was 15,000/month).